### PR TITLE
Allow differently sorted url entries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.1.1] - 2023-04-18
+### Fixed
+- Sort URL list elements before comparing `package.json` and returned `setup.py` data, see #2
+
 ## [0.1.0] - 2023-03-27
 ### Added
 - `setup2upypackage` module
@@ -30,6 +34,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Not used files provided with [template repo](https://github.com/brainelectronics/micropython-i2c-lcd)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.1.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.1.1...main
 
+[0.1.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.0

--- a/src/setup2upypackage/setup2upypackage.py
+++ b/src/setup2upypackage/setup2upypackage.py
@@ -313,7 +313,14 @@ class Setup2uPyPackage(object):
         :returns:   Result of validation, True on success, False otherwise
         :rtype:     bool
         """
-        return self.package_json_data == self.package_data
+        # list of URL entries might be sorted differently
+        package_json_data = dict(self.package_json_data)
+        package_data = dict(self.package_data)
+
+        package_json_data.get("urls", []).sort()
+        package_data.get("urls", []).sort()
+
+        return package_json_data == package_data
 
     @property
     def validation_diff(self) -> DeepDiff:

--- a/tests/test_setup2upypackage.py
+++ b/tests/test_setup2upypackage.py
@@ -6,6 +6,7 @@ import json
 import logging
 import unittest
 from pathlib import Path
+from random import shuffle
 from sys import stdout
 from unittest.mock import PropertyMock, mock_open, patch
 
@@ -305,6 +306,21 @@ class TestSetup2uPyPackage(unittest.TestCase):
             self.assertTrue(is_valid)
         else:
             self.test_logger.warning(s2pp.validation_diff)
+
+        # check for differently sorted URL list entries
+        shuffeled_package_json_data = dict(s2pp.package_json_data)
+        shuffle(shuffeled_package_json_data["urls"])
+        self.assertNotEqual(
+            shuffeled_package_json_data["urls"],
+            s2pp.package_json_data
+        )
+        with patch('setup2upypackage.setup2upypackage.Setup2uPyPackage.package_json_data', new_callable=PropertyMock) as patched:     # noqa: E501
+            patched.return_value = shuffeled_package_json_data
+            is_valid = s2pp.validate()
+            if is_valid:
+                self.assertTrue(is_valid)
+            else:
+                self.test_logger.warning(s2pp.validation_diff)
 
     @unittest.skip("Not yet implemented")
     def test_validation_diff(self) -> None:


### PR DESCRIPTION
### Fixed
- Sort URL list elements before comparing `package.json` and returned `setup.py` data, see #2