### PR TITLE
Optionally ignore version comparision

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ between the generated (based on `setup.py`) and existing package
 ```bash
 upy-package \
     --setup_file tests/data/setup.py \
-    --package_changelog_file tests/data/changelog.md \
+    --package_changelog_file tests/data/sample_changelog.md \
     --package_file tests/data/package.json \
     --validate
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.2.0] - 2023-05-27
+### Added
+- Version of package can be ignored during the check with `--ignore-version`, see #4
+
 ## [0.1.1] - 2023-04-18
 ### Fixed
 - Sort URL list elements before comparing `package.json` and returned `setup.py` data, see #2
@@ -34,7 +38,8 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Not used files provided with [template repo](https://github.com/brainelectronics/micropython-i2c-lcd)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.1.1...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.2.0...main
 
+[0.2.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.2.0
 [0.1.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.0

--- a/src/setup2upypackage/main.py
+++ b/src/setup2upypackage/main.py
@@ -97,6 +97,12 @@ def parse_arguments() -> argparse.Namespace:
                         required=False,
                         help='Validate existing package.json with setup.py based data')  # noqa: E501
 
+    parser.add_argument('--ignore-version',
+                        dest='ignore_version',
+                        action='store_true',
+                        required=False,
+                        help='Exclude version value from check ')
+
     parser.add_argument('--print',
                         dest='print_result',
                         required=False,
@@ -141,6 +147,7 @@ def main():
     dump_to_file = args.dump_to_file
     print_result = args.print_result
     pretty_output = args.pretty_output
+    ignore_version = args.ignore_version
 
     setup_2_upy_package = Setup2uPyPackage(
         setup_file=setup_file,
@@ -151,7 +158,7 @@ def main():
     package_data = setup_2_upy_package.package_data
 
     if do_validate:
-        if not setup_2_upy_package.validate():
+        if not setup_2_upy_package.validate(ignore_version=ignore_version):
             diff = setup_2_upy_package.validation_diff
 
             if pretty_output:

--- a/src/setup2upypackage/setup2upypackage.py
+++ b/src/setup2upypackage/setup2upypackage.py
@@ -306,9 +306,12 @@ class Setup2uPyPackage(object):
 
         return existing_data
 
-    def validate(self) -> bool:
+    def validate(self, ignore_version: bool = False) -> bool:
         """
         Validate existing package.json with setup.py based data
+
+        :param      ignore_version:  Indicates if the version is ignored
+        :type       ignore_version:  bool
 
         :returns:   Result of validation, True on success, False otherwise
         :rtype:     bool
@@ -316,6 +319,10 @@ class Setup2uPyPackage(object):
         # list of URL entries might be sorted differently
         package_json_data = dict(self.package_json_data)
         package_data = dict(self.package_data)
+
+        if ignore_version:
+            package_json_data.pop("version")
+            package_data.pop("version")
 
         package_json_data.get("urls", []).sort()
         package_data.get("urls", []).sort()

--- a/tests/test_setup2upypackage.py
+++ b/tests/test_setup2upypackage.py
@@ -322,6 +322,21 @@ class TestSetup2uPyPackage(unittest.TestCase):
             else:
                 self.test_logger.warning(s2pp.validation_diff)
 
+        # check for different version entries
+        diff_version_package_json_data = dict(s2pp.package_json_data)
+        diff_version_package_json_data["version"] = "93.10.22"
+        self.assertNotEqual(
+            diff_version_package_json_data["version"],
+            s2pp.package_json_data
+        )
+        with patch('setup2upypackage.setup2upypackage.Setup2uPyPackage.package_json_data', new_callable=PropertyMock) as patched:     # noqa: E501
+            patched.return_value = diff_version_package_json_data
+            is_valid = s2pp.validate(ignore_version=True)
+            if is_valid:
+                self.assertTrue(is_valid)
+            else:
+                self.test_logger.warning(s2pp.validation_diff)
+
     @unittest.skip("Not yet implemented")
     def test_validation_diff(self) -> None:
         """Test validation difference property"""


### PR DESCRIPTION
### Added
- Version of package can be ignored during the check with `--ignore-version`, see #4
