### PR TITLE
Optionally ignore deps comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ MicroPython Package Validation for mip package.json files
     - [Validate](#validate)
         - [Validate package JSON file](#validate-package-json-file)
         - [Validate package JSON file from changelog](#validate-package-json-file-from-changelog)
+        - [Options](#options)
     - [Create](#create)
         - [Create package JSON file](#create-package-json-file)
             - [Create specific package JSON file](#create-specific-package-json-file)
@@ -96,6 +97,12 @@ upy-package \
     --package_file tests/data/package.json \
     --validate
 ```
+
+#### Options
+
+To not take the version or the dependencies specified in the `package.json`
+file during a validation run, use the `--ignore-version` or `--ignore-deps`
+argument.
 
 ### Create
 #### Create package JSON file

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.3.0] - 2023-05-27
+### Added
+- Dependencies of package can be ignored during the check with `--ignore-deps`, see #5
+
 ## [0.2.0] - 2023-05-27
 ### Added
 - Version of package can be ignored during the check with `--ignore-version`, see #4
@@ -38,8 +42,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Not used files provided with [template repo](https://github.com/brainelectronics/micropython-i2c-lcd)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.2.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.3.0...main
 
+[0.3.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.2.0
 [0.1.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.1
 [0.1.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.0

--- a/src/setup2upypackage/main.py
+++ b/src/setup2upypackage/main.py
@@ -101,7 +101,13 @@ def parse_arguments() -> argparse.Namespace:
                         dest='ignore_version',
                         action='store_true',
                         required=False,
-                        help='Exclude version value from check ')
+                        help='Exclude version from check')
+
+    parser.add_argument('--ignore-deps',
+                        dest='ignore_deps',
+                        action='store_true',
+                        required=False,
+                        help='Exclude dependencies from check')
 
     parser.add_argument('--print',
                         dest='print_result',
@@ -148,6 +154,7 @@ def main():
     print_result = args.print_result
     pretty_output = args.pretty_output
     ignore_version = args.ignore_version
+    ignore_deps = args.ignore_deps
 
     setup_2_upy_package = Setup2uPyPackage(
         setup_file=setup_file,
@@ -158,7 +165,11 @@ def main():
     package_data = setup_2_upy_package.package_data
 
     if do_validate:
-        if not setup_2_upy_package.validate(ignore_version=ignore_version):
+        validation_result = setup_2_upy_package.validate(
+            ignore_version=ignore_version,
+            ignore_deps=ignore_deps)
+
+        if validation_result is False:
             diff = setup_2_upy_package.validation_diff
 
             if pretty_output:

--- a/src/setup2upypackage/setup2upypackage.py
+++ b/src/setup2upypackage/setup2upypackage.py
@@ -306,12 +306,16 @@ class Setup2uPyPackage(object):
 
         return existing_data
 
-    def validate(self, ignore_version: bool = False) -> bool:
+    def validate(self,
+                 ignore_version: bool = False,
+                 ignore_deps: bool = False) -> bool:
         """
         Validate existing package.json with setup.py based data
 
         :param      ignore_version:  Indicates if the version is ignored
         :type       ignore_version:  bool
+        :param      ignore_deps:     Indicates if the dependencies are ignored
+        :type       ignore_deps:     bool
 
         :returns:   Result of validation, True on success, False otherwise
         :rtype:     bool
@@ -323,6 +327,10 @@ class Setup2uPyPackage(object):
         if ignore_version:
             package_json_data.pop("version")
             package_data.pop("version")
+
+        if ignore_deps:
+            package_json_data.pop("deps")
+            package_data.pop("deps")
 
         package_json_data.get("urls", []).sort()
         package_data.get("urls", []).sort()

--- a/tests/test_setup2upypackage.py
+++ b/tests/test_setup2upypackage.py
@@ -337,6 +337,24 @@ class TestSetup2uPyPackage(unittest.TestCase):
             else:
                 self.test_logger.warning(s2pp.validation_diff)
 
+        # check for different dependencies entries
+        diff_deps_package_json_data = dict(s2pp.package_json_data)
+        diff_deps_package_json_data["deps"] = [
+            "github:brainelectronics/dependency_1",
+            "github:brainelectronics/dependency_2"
+        ]
+        self.assertNotEqual(
+            diff_deps_package_json_data["deps"],
+            s2pp.package_json_data
+        )
+        with patch('setup2upypackage.setup2upypackage.Setup2uPyPackage.package_json_data', new_callable=PropertyMock) as patched:     # noqa: E501
+            patched.return_value = diff_deps_package_json_data
+            is_valid = s2pp.validate(ignore_deps=True)
+            if is_valid:
+                self.assertTrue(is_valid)
+            else:
+                self.test_logger.warning(s2pp.validation_diff)
+
     @unittest.skip("Not yet implemented")
     def test_validation_diff(self) -> None:
         """Test validation difference property"""


### PR DESCRIPTION
### Added
- Dependencies of package can be ignored during the check with `--ignore-deps`, see #5
