### PR TITLE
Ignore boot and main in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ upy-package \
 
 To not take the version or the dependencies specified in the `package.json`
 file during a validation run, use the `--ignore-version` or `--ignore-deps`
-argument.
+argument. Additionally added `boot.py` and `main.py` files in `package.json`
+can be ignored using `--ignore-boot-main` during a validation run.
 
 ### Create
 #### Create package JSON file

--- a/changelog.md
+++ b/changelog.md
@@ -17,9 +17,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
-## [0.4.0] - 2023-06-07
+## [0.4.0] - 2023-06-10
 ### Added
-- `boot.py` and `main.py` can be ignored during the check with `--ignore-boot-main`, see #8
+- `*/boot.py` and `*/main.py` can be ignored during the check with `--ignore-boot-main`, see #8
 
 ## [0.3.0] - 2023-05-27
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.4.0] - 2023-06-07
+### Added
+- `boot.py` and `main.py` can be ignored during the check with `--ignore-boot-main`, see #8
+
 ## [0.3.0] - 2023-05-27
 ### Added
 - Dependencies of package can be ignored during the check with `--ignore-deps`, see #5
@@ -42,8 +46,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Not used files provided with [template repo](https://github.com/brainelectronics/micropython-i2c-lcd)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.3.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.4.0...main
 
+[0.4.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.4.0
 [0.3.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.3.0
 [0.2.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.2.0
 [0.1.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.1.1

--- a/src/setup2upypackage/main.py
+++ b/src/setup2upypackage/main.py
@@ -109,6 +109,12 @@ def parse_arguments() -> argparse.Namespace:
                         required=False,
                         help='Exclude dependencies from check')
 
+    parser.add_argument('--ignore-boot-main',
+                        dest='ignore_boot_main',
+                        action='store_true',
+                        required=False,
+                        help='Boot and main files from check')
+
     parser.add_argument('--print',
                         dest='print_result',
                         required=False,
@@ -155,6 +161,7 @@ def main():
     pretty_output = args.pretty_output
     ignore_version = args.ignore_version
     ignore_deps = args.ignore_deps
+    ignore_boot_main = args.ignore_boot_main
 
     setup_2_upy_package = Setup2uPyPackage(
         setup_file=setup_file,
@@ -167,7 +174,8 @@ def main():
     if do_validate:
         validation_result = setup_2_upy_package.validate(
             ignore_version=ignore_version,
-            ignore_deps=ignore_deps)
+            ignore_deps=ignore_deps,
+            ignore_boot_main=ignore_boot_main)
 
         if validation_result is False:
             diff = setup_2_upy_package.validation_diff

--- a/src/setup2upypackage/setup2upypackage.py
+++ b/src/setup2upypackage/setup2upypackage.py
@@ -366,7 +366,10 @@ class Setup2uPyPackage(object):
         :returns:   List without elements matching the exclude list
         :rtype:     List[Tuple[str, str]]
         """
-        return [ele for ele in package_files if ele[0] not in excludes]
+        return [
+            ele for ele in package_files
+            if not any(i in ele[0] for i in excludes)
+        ]
 
     @property
     def validation_diff(self) -> DeepDiff:

--- a/tests/test_setup2upypackage.py
+++ b/tests/test_setup2upypackage.py
@@ -362,7 +362,7 @@ class TestSetup2uPyPackage(unittest.TestCase):
             "github:brainelectronics/micropython-package-validation/boot.py"
         ])
         diff_urls_package_json_data.get("urls").append([
-            "main.py",
+            "asdf/main.py",
             "github:brainelectronics/micropython-package-validation/main.py"
         ])
         self.assertNotEqual(


### PR DESCRIPTION
### Added
- `*/boot.py` and `*/main.py` can be ignored during the check with `--ignore-boot-main`, see #8