### PR TITLE
CLI arg package_file existance is not evaluated on argparse level

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ the `--pretty` option)
 ```bash
 upy-package \
     --setup_file tests/data/setup.py \
-    --create \
+    --create \
     --print \
     --pretty
 ```
@@ -131,7 +131,7 @@ parameter. The file has to exist before running the command.
 upy-package \
     --setup_file tests/data/setup.py \
     --package_file tests/data/custom-package.json \
-    --create \
+    --create \
     --print \
     --pretty
 ```
@@ -147,7 +147,7 @@ be specified explicitly to use its latest entry for the version value.
 upy-package \
     --setup_file tests/data/setup.py \
     --package_changelog_file tests/data/sample_changelog.md \
-    --create \
+    --create \
     --print \
     --pretty
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.6.1] - 2026-04-28
+### Fixed
+- Raise a `FileNotFoundError` if the specified `package_file` is not found during validation. The file will be created with the `--create` option without throwing an error due to non-existance on CLI arg parsing level.
+
 ## [0.6.0] - 2026-04-27
 ### Added
 - `.python-version` to use repo this with pyenv
@@ -71,8 +75,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Not used files provided with [template repo](https://github.com/brainelectronics/micropython-i2c-lcd)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.6.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.6.1...main
 
+[0.6.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.6.1
 [0.6.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.6.0
 [0.5.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.5.1
 [0.5.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.5.0

--- a/src/setup2upypackage/main.py
+++ b/src/setup2upypackage/main.py
@@ -76,7 +76,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument('--package_file',
                         dest='package_file',
                         required=False,
-                        type=lambda x: parser_valid_file(parser, x),
+                        type=Path,
                         help='Path to package.json file')
 
     parser.add_argument('--package_changelog_file',

--- a/src/setup2upypackage/setup2upypackage.py
+++ b/src/setup2upypackage/setup2upypackage.py
@@ -298,6 +298,9 @@ class Setup2uPyPackage(object):
         """
         existing_data = {}
 
+        if self._package_file and not Path(self._package_file).exists():
+            raise FileNotFoundError(self._package_file)
+
         if self._package_file:
             with open(self._package_file, 'r') as f:
                 existing_data = json.load(f)


### PR DESCRIPTION
... to be able to specify a package_file for creation. A dedicated FileNotFoundError is raised when accessing the package.json file e.g. during validation