### PR TITLE
Send validation diff to stderr

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,6 @@ repos:
     hooks:
       - id: yamllint
         args: [--strict, -c=.yamllint]
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
   # this is a dirty hack to prepare the folder structure for nose2
   # only the order of hooks ensures this hook is executed before the nose2 hook
   - repo: local
@@ -27,6 +23,11 @@ repos:
         entry: python create_report_dirs.py
         language: system
         pass_filenames: false
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: [--output-file=reports/sca/flake8.out]
   - repo: local
     hooks:
       - id: nose2
@@ -35,3 +36,5 @@ repos:
         language: python
         pass_filenames: false
         types: [file, python]
+        additional_dependencies:
+          - "setup2upypackage[test]"

--- a/README.md
+++ b/README.md
@@ -74,10 +74,19 @@ pip install setup2upypackage
 
 The optional arg `--pretty` can be used to output human readable content instead of JSON data in case of a failure.
 
-The machine readable JSON output might look like and can directly be processed with e.g. `jq`:
+The machine readable JSON output might look like and can directly be processed with e.g. `jq` using `upy-package ... --validate 2> >(jq -r '.')`:
 
 ```json
-{"values_changed": {"root['urls'][1][0]": {"new_value": "be_upy_blink/blink2.py", "old_value": "be_upy_blink/blink.py"}}}
+{
+    "values_changed":
+    {
+        "root['urls'][1][0]":
+        {
+            "new_value": "be_upy_blink/blink2.py",
+            "old_value": "be_upy_blink/blink.py"
+        }
+    }
+}
 ```
 
 The human readable output using `--pretty` might look like:

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 -->
 
 ## Released
+## [0.9.0] - 2026-05-01
+### Changed
+- Machine readable JSON of failed validation diff is printed to `stderr` instead of `stdout` to be usable with `upy-package ... --validate [--debug -vvvvv] 2> >(jq -r '.values_changed')` even if debug logging is enabled
+
 ## [0.8.0] - 2026-05-01
 ### Added
 - Extended documentation for pre-commit installation and usage
@@ -97,8 +101,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 - Not used files provided with [template repo](https://github.com/brainelectronics/micropython-i2c-lcd)
 
 <!-- Links -->
-[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.8.0...main
+[Unreleased]: https://github.com/brainelectronics/micropython-package-validation/compare/0.9.0...main
 
+[0.9.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.9.0
 [0.8.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.8.0
 [0.7.0]: https://github.com/brainelectronics/micropython-package-validation/tree/0.7.0
 [0.6.1]: https://github.com/brainelectronics/micropython-package-validation/tree/0.6.1

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,7 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 
 ### Fixed
 - Print new line after pretty printed diff on failed validation
+- Install package as additional dependency to run `nose2` tests
 
 ## [0.8.0] - 2026-05-01
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ r"^\#\# \[\d{1,}[.]\d{1,}[.]\d{1,}\] \- \d{4}\-\d{2}-\d{2}$"
 ### Changed
 - Machine readable JSON of failed validation diff is printed to `stderr` instead of `stdout` to be usable with `upy-package ... --validate [--debug -vvvvv] 2> >(jq -r '.values_changed')` even if debug logging is enabled
 
+### Fixed
+- Print new line after pretty printed diff on failed validation
+
 ## [0.8.0] - 2026-05-01
 ### Added
 - Extended documentation for pre-commit installation and usage

--- a/src/setup2upypackage/main.py
+++ b/src/setup2upypackage/main.py
@@ -200,7 +200,8 @@ def main():
                     )
                 )
             else:
-                stdout.write(json.dumps(diff))
+                # make the output machine readable even with debug logging
+                stderr.write(json.dumps(diff))
 
             return 1
 

--- a/src/setup2upypackage/main.py
+++ b/src/setup2upypackage/main.py
@@ -192,7 +192,7 @@ def main():
 
             if pretty_output:
                 # pretty processing is done by validation_diff
-                stdout.write(diff)
+                stdout.write(diff + "\n")
                 stderr.write(
                     'Mismatch between "{}" and "{}"\n'.format(
                         setup_file.name,


### PR DESCRIPTION
### Changed
- Machine readable JSON of failed validation diff is printed to `stderr` instead of `stdout` to be usable with `upy-package ... --validate [--debug -vvvvv] 2> >(jq -r '.values_changed')` even if debug logging is enabled

### Fixed
- Print new line after pretty printed diff on failed validation
- Install package as additional dependency to run `nose2` tests
